### PR TITLE
Secure Arweave wallet admin route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,4 +59,9 @@ MINER_USE_HTTPS=false
 # Set to false only for self-signed certs during local dev (never in production)
 VALIDATOR_TLS_VERIFY=true
 
+# Web admin endpoints
+# Required for privileged Next.js API routes such as /api/arweave/wallet.
+# Generate with: openssl rand -base64 32
+ENGRAM_ADMIN_TOKEN=
+
 LOG_LEVEL=INFO

--- a/engram-web/app/api/arweave/wallet/route.ts
+++ b/engram-web/app/api/arweave/wallet/route.ts
@@ -1,39 +1,84 @@
 /**
  * GET /api/arweave/wallet
  *
- * Returns the current Arweave wallet address and AR balance.
- * If ARWEAVE_KEY is not set, generates a fresh wallet and returns
- * the JWK so the operator can fund it and set the env var.
- *
- * Only callable server-side / by admins — do not expose publicly.
+ * Authenticated admin endpoint for the current Arweave wallet address/balance.
+ * Never returns wallet key material. Generate ARWEAVE_KEY locally and set it as
+ * an environment variable instead of moving JWK private keys over HTTP.
  */
+import { timingSafeEqual } from "crypto";
 import { NextResponse } from "next/server";
-import { generateWallet, getWalletBalance } from "@/lib/arweave";
+import { getWalletBalance } from "@/lib/arweave";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
-export async function GET() {
+const ADMIN_TOKEN = process.env.ENGRAM_ADMIN_TOKEN ?? "";
+const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
+
+function tokenMatches(provided: string, expected: string): boolean {
+  if (!provided || !expected) return false;
+
+  const providedBuffer = Buffer.from(provided);
+  const expectedBuffer = Buffer.from(expected);
+
+  if (providedBuffer.length !== expectedBuffer.length) return false;
+  return timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+function bearerToken(req: Request): string {
+  const header = req.headers.get("authorization") ?? "";
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() ?? "";
+}
+
+export async function GET(req: Request) {
+  if (!ADMIN_TOKEN) {
+    return NextResponse.json(
+      { error: "ENGRAM_ADMIN_TOKEN is not configured on this server." },
+      { status: 503, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  if (!tokenMatches(bearerToken(req), ADMIN_TOKEN)) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      {
+        status: 401,
+        headers: {
+          ...NO_STORE_HEADERS,
+          "WWW-Authenticate": "Bearer",
+        },
+      }
+    );
+  }
+
   if (!process.env.ARWEAVE_KEY) {
-    // No wallet configured — generate one
-    const { key, address } = await generateWallet();
-    return NextResponse.json({
-      status: "no_wallet",
-      message: "No ARWEAVE_KEY set. Save the key below as your ARWEAVE_KEY env var, then fund the address with AR.",
-      address,
-      key, // JWK — treat as a private key, store securely
-    });
+    return NextResponse.json(
+      {
+        status: "no_wallet",
+        message:
+          "No ARWEAVE_KEY is configured. Generate a wallet locally and set the JWK JSON as ARWEAVE_KEY; this endpoint never returns private key material.",
+      },
+      { status: 503, headers: NO_STORE_HEADERS }
+    );
   }
 
   try {
     const { address, ar } = await getWalletBalance();
-    return NextResponse.json({
-      status: "ok",
-      address,
-      balance_ar: ar,
-      env: process.env.ARWEAVE_ENV ?? "mainnet",
-    });
+    return NextResponse.json(
+      {
+        status: "ok",
+        address,
+        balance_ar: ar,
+        env: process.env.ARWEAVE_ENV ?? "mainnet",
+      },
+      { headers: NO_STORE_HEADERS }
+    );
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ status: "error", error: msg }, { status: 500 });
+    return NextResponse.json(
+      { status: "error", error: msg },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
   }
 }


### PR DESCRIPTION
## Summary
- require an admin bearer token for `/api/arweave/wallet`
- fail closed when `ENGRAM_ADMIN_TOKEN` is missing
- remove HTTP generation/return of Arweave JWK private keys
- document `ENGRAM_ADMIN_TOKEN` in `.env.example`

## Verification
- `npm run build`
- `git diff --check`

Closes #1