### PR TITLE
Wire signed namespace fields through miner HTTP

### DIFF
--- a/engram/miner/http_synapses.py
+++ b/engram/miner/http_synapses.py
@@ -1,0 +1,36 @@
+"""Helpers for converting miner HTTP JSON bodies into protocol synapses."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from engram.protocol import IngestSynapse, QuerySynapse
+
+
+def ingest_synapse_from_body(body: dict[str, Any]) -> IngestSynapse:
+    """Build an IngestSynapse from a JSON request body."""
+    return IngestSynapse(
+        text=body.get("text"),
+        raw_embedding=body.get("raw_embedding"),
+        metadata=body.get("metadata") or {},
+        model_version=body.get("model_version") or "v1",
+        namespace=body.get("namespace") or None,
+        namespace_hotkey=body.get("namespace_hotkey") or None,
+        namespace_sig=body.get("namespace_sig") or None,
+        namespace_timestamp_ms=body.get("namespace_timestamp_ms") or None,
+        namespace_key=body.get("namespace_key") or None,
+    )
+
+
+def query_synapse_from_body(body: dict[str, Any]) -> QuerySynapse:
+    """Build a QuerySynapse from a JSON request body."""
+    return QuerySynapse(
+        query_text=body.get("query_text"),
+        query_vector=body.get("query_vector"),
+        top_k=int(body.get("top_k", 10)),
+        namespace=body.get("namespace") or None,
+        namespace_hotkey=body.get("namespace_hotkey") or None,
+        namespace_sig=body.get("namespace_sig") or None,
+        namespace_timestamp_ms=body.get("namespace_timestamp_ms") or None,
+        namespace_key=body.get("namespace_key") or None,
+    )

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -39,12 +39,12 @@ from engram.miner.ingest import IngestHandler
 from engram.miner.metrics import METRICS, generate_latest
 from engram.miner.namespace import NamespaceRegistry
 from engram.miner.attestation import AttestationRegistry
+from engram.miner.http_synapses import ingest_synapse_from_body, query_synapse_from_body
 from engram.miner.query import QueryHandler
 from engram.miner.auth import AuthError, verify_request
 from engram.miner.rate_limiter import RateLimiter
 from engram.miner.wallet_tracker import WalletTracker
 from engram.miner.store import build_store
-from engram.protocol import IngestSynapse, QuerySynapse
 from engram.storage.dht import DHTRouter, Peer
 from engram.storage.replication import ReplicationManager
 from engram.utils.logging import setup_logging
@@ -465,13 +465,7 @@ async def run() -> None:
                 METRICS.ingest_total.labels(status="rate_limited").inc()
                 return web.json_response({"error": str(exc), "hint": "Wait a moment before sending more requests."}, status=429)
 
-            synapse  = IngestSynapse(
-                text          = body.get("text"),
-                raw_embedding = body.get("raw_embedding"),
-                metadata      = body.get("metadata") or {},
-                namespace     = body.get("namespace") or None,
-                namespace_key = body.get("namespace_key") or None,
-            )
+            synapse = ingest_synapse_from_body(body)
             result = await asyncio.get_running_loop().run_in_executor(None, lambda: ingest_handler.handle(synapse, caller_hotkey=caller_hotkey))
             elapsed_ms = (time.perf_counter() - t0) * 1000
             METRICS.ingest_duration.observe(elapsed_ms)
@@ -545,13 +539,7 @@ async def run() -> None:
                 METRICS.query_total.labels(status="rate_limited").inc()
                 return web.json_response({"error": str(exc)}, status=429)
 
-            synapse = QuerySynapse(
-                query_text    = body.get("query_text"),
-                query_vector  = body.get("query_vector"),
-                top_k         = int(body.get("top_k", 10)),
-                namespace     = body.get("namespace") or None,
-                namespace_key = body.get("namespace_key") or None,
-            )
+            synapse = query_synapse_from_body(body)
             is_private = bool(body.get("namespace"))
             result = await asyncio.get_running_loop().run_in_executor(None, query_handler.handle, synapse)
             elapsed_ms = (_time.perf_counter() - t0) * 1000

--- a/tests/test_http_synapses.py
+++ b/tests/test_http_synapses.py
@@ -1,0 +1,69 @@
+"""Regression tests for miner HTTP request body to synapse conversion."""
+
+from __future__ import annotations
+
+from engram.miner.http_synapses import ingest_synapse_from_body, query_synapse_from_body
+
+
+def test_ingest_synapse_from_body_preserves_signed_namespace_fields() -> None:
+    body = {
+        "text": "private memory",
+        "metadata": {"source": "test"},
+        "model_version": "v2",
+        "namespace": "team_alpha",
+        "namespace_hotkey": "5FakeOwner",
+        "namespace_sig": "0xabc123",
+        "namespace_timestamp_ms": 1778112345000,
+    }
+
+    synapse = ingest_synapse_from_body(body)
+
+    assert synapse.text == "private memory"
+    assert synapse.metadata == {"source": "test"}
+    assert synapse.model_version == "v2"
+    assert synapse.namespace == "team_alpha"
+    assert synapse.namespace_hotkey == "5FakeOwner"
+    assert synapse.namespace_sig == "0xabc123"
+    assert synapse.namespace_timestamp_ms == 1778112345000
+    assert synapse.namespace_key is None
+
+
+def test_query_synapse_from_body_preserves_signed_namespace_fields() -> None:
+    body = {
+        "query_text": "private search",
+        "top_k": "7",
+        "namespace": "team_alpha",
+        "namespace_hotkey": "5FakeOwner",
+        "namespace_sig": "0xdef456",
+        "namespace_timestamp_ms": 1778112345001,
+    }
+
+    synapse = query_synapse_from_body(body)
+
+    assert synapse.query_text == "private search"
+    assert synapse.top_k == 7
+    assert synapse.namespace == "team_alpha"
+    assert synapse.namespace_hotkey == "5FakeOwner"
+    assert synapse.namespace_sig == "0xdef456"
+    assert synapse.namespace_timestamp_ms == 1778112345001
+    assert synapse.namespace_key is None
+
+
+def test_synapse_from_body_still_supports_legacy_namespace_key() -> None:
+    ingest = ingest_synapse_from_body({
+        "text": "legacy private memory",
+        "namespace": "legacy_ns",
+        "namespace_key": "legacy-secret",
+    })
+    query = query_synapse_from_body({
+        "query_vector": [0.1, 0.2, 0.3],
+        "namespace": "legacy_ns",
+        "namespace_key": "legacy-secret",
+    })
+
+    assert ingest.namespace == "legacy_ns"
+    assert ingest.namespace_key == "legacy-secret"
+    assert ingest.namespace_sig is None
+    assert query.namespace == "legacy_ns"
+    assert query.namespace_key == "legacy-secret"
+    assert query.namespace_sig is None


### PR DESCRIPTION
## Summary
- preserve signed namespace auth fields when converting HTTP JSON into `IngestSynapse` and `QuerySynapse`
- move request-body mapping into small testable helpers
- add regression coverage for signed namespace fields and legacy `namespace_key` fallback

## Verification
- `.venv/bin/python -m pytest tests/test_http_synapses.py -q`
- `.venv/bin/python -m pytest tests/test_http_synapses.py tests/test_memory_namespace.py tests/test_auth.py -q`
- `python3 -m py_compile engram/miner/http_synapses.py tests/test_http_synapses.py neurons/miner.py`
- `git diff --check`

Closes #2