### PR TITLE
Fix Qdrant list namespace and metadata handling

### DIFF
--- a/engram/miner/store.py
+++ b/engram/miner/store.py
@@ -203,27 +203,45 @@ class QdrantStore(VectorStore):
     ) -> list[dict]:
         from qdrant_client.models import Filter, FieldCondition, MatchValue
 
-        qdrant_filter = None
-        conditions = []
-        if namespace != _PUBLIC_NS:
-            conditions.append(FieldCondition(key="namespace", match=MatchValue(value=namespace)))
+        conditions = [
+            FieldCondition(key="_ns", match=MatchValue(value=namespace)),
+        ]
         if filter:
             for k, v in filter.items():
                 conditions.append(FieldCondition(key=k, match=MatchValue(value=str(v))))
-        if conditions:
-            qdrant_filter = Filter(must=conditions)
+        qdrant_filter = Filter(must=conditions)
 
-        results, _ = self._client.scroll(
-            collection_name=self._collection,
-            scroll_filter=qdrant_filter,
-            limit=limit,
-            offset=offset,
-            with_payload=True,
-            with_vectors=False,
-        )
+        # VectorStore.list(offset=N) means "skip N records". Qdrant's scroll
+        # offset is a point-ID cursor, so page through until we have enough rows.
+        target_count = offset + limit
+        fetched = []
+        scroll_offset = None
+
+        while len(fetched) < target_count:
+            page_limit = max(1, min(256, target_count - len(fetched)))
+            results, scroll_offset = self._client.scroll(
+                collection_name=self._collection,
+                scroll_filter=qdrant_filter,
+                limit=page_limit,
+                offset=scroll_offset,
+                with_payload=True,
+                with_vectors=False,
+            )
+            fetched.extend(results)
+            if scroll_offset is None or not results:
+                break
+
+        page = fetched[offset: offset + limit]
         return [
-            {"cid": r.payload.get("cid", ""), "metadata": r.payload.get("metadata", {})}
-            for r in results
+            {
+                "cid": (r.payload or {}).get("cid", ""),
+                "metadata": {
+                    k: v
+                    for k, v in (r.payload or {}).items()
+                    if k not in ("cid", "_ns")
+                },
+            }
+            for r in page
         ]
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,9 +1,12 @@
-"""Tests for FAISSStore (no external dependencies needed)."""
+"""Tests for vector store implementations."""
+
+import sys
+import types
 
 import numpy as np
 import pytest
 
-from engram.miner.store import FAISSStore, VectorRecord
+from engram.miner.store import FAISSStore, QdrantStore, VectorRecord, _PUBLIC_NS
 
 
 @pytest.fixture
@@ -52,3 +55,129 @@ def test_delete(store):
 def test_search_empty(store):
     results = store.search(np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32))
     assert results == []
+
+
+# ── QdrantStore.list regression tests ────────────────────────────────────────
+
+class _FakeMatchValue:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeFieldCondition:
+    def __init__(self, key, match):
+        self.key = key
+        self.match = match
+
+
+class _FakeFilter:
+    def __init__(self, must):
+        self.must = must
+
+
+class _FakePoint:
+    def __init__(self, payload):
+        self.payload = payload
+
+
+class _FakeQdrantClient:
+    def __init__(self, pages):
+        self.pages = list(pages)
+        self.calls = []
+
+    def scroll(self, **kwargs):
+        self.calls.append(kwargs)
+        if not self.pages:
+            return [], None
+        page, next_offset = self.pages.pop(0)
+        return page, next_offset
+
+
+@pytest.fixture
+def fake_qdrant_models(monkeypatch):
+    qdrant = types.ModuleType("qdrant_client")
+    models = types.ModuleType("qdrant_client.models")
+    models.Filter = _FakeFilter
+    models.FieldCondition = _FakeFieldCondition
+    models.MatchValue = _FakeMatchValue
+    qdrant.models = models
+    monkeypatch.setitem(sys.modules, "qdrant_client", qdrant)
+    monkeypatch.setitem(sys.modules, "qdrant_client.models", models)
+
+
+def _qdrant_store(client: _FakeQdrantClient) -> QdrantStore:
+    store = QdrantStore.__new__(QdrantStore)
+    store._client = client
+    store._collection = "engram"
+    return store
+
+
+def _filter_values(call):
+    return {condition.key: condition.match.value for condition in call["scroll_filter"].must}
+
+
+def test_qdrant_list_filters_public_namespace_and_returns_flat_metadata(fake_qdrant_models):
+    client = _FakeQdrantClient([
+        ([
+            _FakePoint({
+                "cid": "public_cid",
+                "_ns": _PUBLIC_NS,
+                "source": "cli",
+                "type": "text",
+            }),
+        ], None),
+    ])
+    store = _qdrant_store(client)
+
+    records = store.list(namespace=_PUBLIC_NS)
+
+    assert records == [
+        {
+            "cid": "public_cid",
+            "metadata": {"source": "cli", "type": "text"},
+        }
+    ]
+    assert _filter_values(client.calls[0]) == {"_ns": _PUBLIC_NS}
+
+
+def test_qdrant_list_filters_private_namespace_with_metadata(fake_qdrant_models):
+    client = _FakeQdrantClient([
+        ([
+            _FakePoint({
+                "cid": "private_cid",
+                "_ns": "team_alpha",
+                "source": "sdk",
+                "type": "pdf",
+            }),
+        ], None),
+    ])
+    store = _qdrant_store(client)
+
+    records = store.list(filter={"type": "pdf"}, namespace="team_alpha")
+
+    assert records == [
+        {
+            "cid": "private_cid",
+            "metadata": {"source": "sdk", "type": "pdf"},
+        }
+    ]
+    assert _filter_values(client.calls[0]) == {"_ns": "team_alpha", "type": "pdf"}
+
+
+def test_qdrant_list_treats_offset_as_skip_count(fake_qdrant_models):
+    client = _FakeQdrantClient([
+        ([
+            _FakePoint({"cid": "cid_1", "_ns": _PUBLIC_NS}),
+            _FakePoint({"cid": "cid_2", "_ns": _PUBLIC_NS}),
+        ], "cursor_2"),
+        ([
+            _FakePoint({"cid": "cid_3", "_ns": _PUBLIC_NS}),
+        ], None),
+    ])
+    store = _qdrant_store(client)
+
+    records = store.list(limit=2, offset=1)
+
+    assert [record["cid"] for record in records] == ["cid_2", "cid_3"]
+    assert client.calls[0]["offset"] is None
+    assert client.calls[1]["offset"] == "cursor_2"


### PR DESCRIPTION
## Summary
- make `QdrantStore.list()` consistently filter on the stored `_ns` namespace payload field
- return flat metadata consistently with `search()`/`get()` instead of looking for a nested `metadata` object
- preserve the public `offset=N` skip-count API while using Qdrant scroll cursors internally
- add mocked Qdrant regression tests that do not require a live Qdrant server

## Verification
- `.venv/bin/python -m pytest tests/test_store.py tests/test_memory_namespace.py -q` — 27 passed
- `python3 -m py_compile engram/miner/store.py tests/test_store.py`
- `git diff --check`

## Note
- Full local `.venv/bin/python -m pytest -q` is blocked by missing local dependency `cryptography`; failures are isolated to `tests/test_hybrid_encryption.py` import errors. The run reached 196 passed, 9 skipped, 22 failed due to that missing package.

Closes #5