### PR TITLE
Use Rust core for miner proof responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,14 @@ jobs:
           challenge = engram_core.generate_challenge(cid, 30)
           response = engram_core.generate_response(challenge, [0.1, 0.2, 0.3])
           assert engram_core.verify_response(challenge, response, [0.1, 0.2, 0.3])
+          response2 = engram_core.generate_response_from_parts(
+              challenge.cid,
+              challenge.nonce_hex,
+              challenge.expires_at,
+              [0.1, 0.2, 0.3],
+          )
+          assert response2.proof == response.proof
+          assert response2.embedding_hash == response.embedding_hash
 
           # Batch proof
           cid2 = engram_core.generate_cid([0.4, 0.5, 0.6], {}, 'v1')

--- a/engram-core/src/lib.rs
+++ b/engram-core/src/lib.rs
@@ -117,6 +117,24 @@ fn generate_response(challenge: &Challenge, embedding: Vec<f32>) -> ProofRespons
 }
 
 #[pyfunction]
+fn generate_response_from_parts(
+    cid: &str,
+    nonce_hex: &str,
+    expires_at: u64,
+    embedding: Vec<f32>,
+) -> PyResult<ProofResponse> {
+    let nonce_vec = hex::decode(nonce_hex)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("invalid nonce hex: {e}")))?;
+    let nonce: [u8; 32] = nonce_vec
+        .try_into()
+        .map_err(|_| pyo3::exceptions::PyValueError::new_err("nonce must be exactly 32 bytes"))?;
+
+    Ok(ProofResponse {
+        inner: proof::generate_response_from_parts(cid, nonce, expires_at, &embedding),
+    })
+}
+
+#[pyfunction]
 fn verify_response(
     challenge: &Challenge,
     response: &ProofResponse,
@@ -238,6 +256,7 @@ fn engram_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ProofResponse>()?;
     m.add_function(wrap_pyfunction!(generate_challenge, m)?)?;
     m.add_function(wrap_pyfunction!(generate_response, m)?)?;
+    m.add_function(wrap_pyfunction!(generate_response_from_parts, m)?)?;
     m.add_function(wrap_pyfunction!(verify_response, m)?)?;
     // Batch proofs
     m.add_class::<BatchChallenge>()?;

--- a/engram-core/src/proof.rs
+++ b/engram-core/src/proof.rs
@@ -132,6 +132,25 @@ pub fn generate_response(challenge: &Challenge, embedding: &[f32]) -> ProofRespo
     }
 }
 
+/// Generate a proof response from raw challenge fields.
+///
+/// This is useful at protocol boundaries where the miner receives JSON fields
+/// rather than a Rust Challenge object.
+pub fn generate_response_from_parts(
+    cid: &str,
+    nonce: [u8; 32],
+    expires_at: u64,
+    embedding: &[f32],
+) -> ProofResponse {
+    let challenge = Challenge {
+        nonce,
+        cid: cid.to_string(),
+        issued_at: 0,
+        expires_at,
+    };
+    generate_response(&challenge, embedding)
+}
+
 // ── Validator Side — batch CIDs ───────────────────────────────────────────────
 
 /// Generate a batch challenge covering multiple CIDs in one round trip.
@@ -338,6 +357,24 @@ mod tests {
         let challenge = generate_challenge("v1::abc123", 60);
         let response = generate_response(&challenge, &emb);
         assert!(verify_response(&challenge, &response, &emb));
+    }
+
+    #[test]
+    fn response_from_parts_matches_challenge_response() {
+        let emb = dummy_embedding();
+        let challenge = generate_challenge("v1::abc123", 60);
+        let response = generate_response(&challenge, &emb);
+        let from_parts = generate_response_from_parts(
+            &challenge.cid,
+            challenge.nonce,
+            challenge.expires_at,
+            &emb,
+        );
+        assert_eq!(from_parts.cid, response.cid);
+        assert_eq!(from_parts.nonce_hex, response.nonce_hex);
+        assert_eq!(from_parts.embedding_hash, response.embedding_hash);
+        assert_eq!(from_parts.proof, response.proof);
+        assert!(verify_response(&challenge, &from_parts, &emb));
     }
 
     #[test]

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -51,10 +51,17 @@ from engram.utils.logging import setup_logging
 
 setup_logging(os.getenv("LOG_LEVEL", "INFO"))
 
+try:
+    import engram_core
+    _RUST_PROOF_AVAILABLE = hasattr(engram_core, "generate_response_from_parts")
+except ImportError:
+    engram_core = None
+    _RUST_PROOF_AVAILABLE = False
+
 
 # ── Storage proof helpers ─────────────────────────────────────────────────────
-# Mirrors Rust proof.rs logic exactly: SHA-256 over little-endian f32 bytes,
-# then HMAC-SHA256 with nonce as key and embedding_hash hex as message.
+# Rust is the source of truth. The Python path is a fallback for local/dev
+# environments that have not rebuilt engram-core yet.
 
 def _hash_embedding(embedding: list[float]) -> str:
     emb_bytes = struct.pack(f"<{len(embedding)}f", *embedding)
@@ -71,6 +78,23 @@ def _proof_response(nonce_hex: str, embedding: list[float]) -> tuple[str, str]:
     embedding_hash = _hash_embedding(embedding)
     proof = _compute_proof(nonce, embedding_hash)
     return embedding_hash, proof
+
+
+def _proof_response_for_challenge(
+    cid: str,
+    nonce_hex: str,
+    expires_at: int,
+    embedding: list[float],
+) -> tuple[str, str]:
+    if _RUST_PROOF_AVAILABLE and engram_core is not None:
+        response = engram_core.generate_response_from_parts(
+            cid,
+            nonce_hex,
+            expires_at,
+            embedding,
+        )
+        return response.embedding_hash, response.proof
+    return _proof_response(nonce_hex, embedding)
 
 
 # ── Chat history store (SQLite) ───────────────────────────────────────────────
@@ -672,7 +696,12 @@ async def run() -> None:
             if record is None:
                 return web.json_response({"error": f"Nothing stored under that CID ({cid[:20]}…). This miner may not hold a replica of it."}, status=404)
 
-            embedding_hash, proof = _proof_response(nonce_hex, record.embedding.tolist())
+            embedding_hash, proof = _proof_response_for_challenge(
+                cid,
+                nonce_hex,
+                expires_at,
+                record.embedding.tolist(),
+            )
             _challenge_total += 1
             _challenge_ok += 1
             return web.json_response({"embedding_hash": embedding_hash, "proof": proof})

--- a/tests/test_memory_proofs.py
+++ b/tests/test_memory_proofs.py
@@ -24,6 +24,7 @@ except ImportError:
     _RUST = False
 
 _BATCH = _RUST and hasattr(engram_core, "generate_batch_challenge")
+_PARTS = _RUST and hasattr(engram_core, "generate_response_from_parts")
 
 pytestmark = pytest.mark.skipif(not _RUST, reason="engram_core Rust module not built")
 
@@ -118,6 +119,24 @@ def test_response_fields() -> None:
     assert resp.nonce_hex == ch.nonce_hex
     assert len(resp.embedding_hash) == 64
     assert len(resp.proof) == 64
+
+
+@pytest.mark.skipif(not _PARTS, reason="raw proof response API not in installed wheel (rebuild needed)")
+def test_response_from_parts_matches_response() -> None:
+    cid = make_cid(EMB_A)
+    ch = engram_core.generate_challenge(cid, 60)
+    resp = engram_core.generate_response(ch, EMB_A)
+    from_parts = engram_core.generate_response_from_parts(
+        ch.cid,
+        ch.nonce_hex,
+        ch.expires_at,
+        EMB_A,
+    )
+    assert from_parts.cid == resp.cid
+    assert from_parts.nonce_hex == resp.nonce_hex
+    assert from_parts.embedding_hash == resp.embedding_hash
+    assert from_parts.proof == resp.proof
+    assert engram_core.verify_response(ch, from_parts, EMB_A)
 
 
 def test_each_challenge_has_unique_nonce() -> None:


### PR DESCRIPTION
## Summary
- add `engram_core.generate_response_from_parts()` for proof responses from raw challenge fields
- keep Rust as the source of truth for miner proof response generation
- make `neurons/miner.py` use the Rust helper when available, with the current Python implementation retained as a dev fallback
- add Rust, Python, and CI smoke coverage for the new binding

## Verification
- `cargo test --manifest-path engram-core/Cargo.toml --no-default-features` — 15 passed
- `.venv/bin/python -m maturin develop --manifest-path engram-core/Cargo.toml`
- `.venv/bin/python -m pytest tests/test_memory_proofs.py -q` — 29 passed
- `.venv/bin/python - <<'PY' ... generate_response_from_parts smoke ... PY`
- `python3 -m py_compile neurons/miner.py`
- `git diff --check`

## Note
- `cargo fmt --check` reports formatting drift in pre-existing Rust files, so this PR avoids broad unrelated formatting churn.

Refs #9