### PR TITLE
feat: add OpenAPI 3 spec for miner HTTP endpoints (closes #23)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,102 @@
+openapi: 3.0.0
+info:
+  title: Engram Miner API
+  description: API specification for Engram miner HTTP endpoints
+  version: 1.0.0
+servers:
+  - url: http://localhost:8000
+    description: Local development server
+
+components:
+  securitySchemes:
+    Sr25519Signature:
+      type: apiKey
+      in: header
+      name: X-Sr25519-Signature
+      description: Sr25519 signed challenge header for authentication
+
+paths:
+  /ingest:
+    post:
+      summary: Ingest data into the Engram network
+      security:
+        - Sr25519Signature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: string
+                  description: Data to ingest
+                namespace:
+                  type: string
+                  description: Optional namespace for private data
+              required:
+                - data
+      responses:
+        '200':
+          description: Data ingested successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  message:
+                    type: string
+        '401':
+          description: Unauthorized - invalid signature
+  
+  /query:
+    post:
+      summary: Query data from the Engram network
+      security:
+        - Sr25519Signature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+                  description: Query string
+                limit:
+                  type: integer
+                  description: Maximum number of results
+              required:
+                - query
+      responses:
+        '200':
+          description: Query results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+        '401':
+          description: Unauthorized - invalid signature
+
+  /health:
+    get:
+      summary: Health check endpoint
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: healthy


### PR DESCRIPTION
## Summary
This PR adds a machine-readable OpenAPI 3 specification for the Engram miner HTTP endpoints, as requested in issue #23.

## Changes
- Created `docs/openapi.yaml` with OpenAPI 3 spec
- Documented authentication scheme (Sr25519 signed-challenge headers)
- Included example endpoints: `/ingest`, `/query`, `/health`

## Implementation Notes
- The spec is a starting point based on the miner.py analysis
- Currently includes the main endpoints identified from `neurons/miner.py`
- Authentication scheme documented (sr25519 signed-challenge headers)

## Next Steps (mentioned in issue)
- [x] Generate an OpenAPI 3 spec from the miner's route definitions
- [x] Include auth scheme docs (sr25519 signed-challenge headers)
- [ ] Publish rendered docs (e.g. Redoc page under `docs/` or theengram.space)
- [ ] CI check that the spec stays in sync with routes

## Acceptance Criteria
- [x] Keep the pull request focused
- [x] Include a short summary of the change
- [x] Link this issue in the pull request description

Closes #23

## Feedback Requested
Please review the spec and let me know if I missed any endpoints or need to adjust the authentication documentation.
